### PR TITLE
Fix comment typo in nendoroid notebook

### DIFF
--- a/nendoroid.ipynb
+++ b/nendoroid.ipynb
@@ -15,7 +15,7 @@
       },
       "outputs": [],
       "source": [
-        "#(2.1) モデルのダウンロード（nendroid）\n",
+        "#(2.1) モデルのダウンロード（nendoroid）\n",
         "%cd /notebooks/stable-diffusion-webui/models/Stable-diffusion\n",
         "!wget -nc https://civitai.com/api/download/models/46846 -O revAnimated_v122.safetensors\n",
         "\n",


### PR DESCRIPTION
## Summary
- correct typo `nendroid` -> `nendoroid` in `nendoroid.ipynb`

## Testing
- `python - <<'EOF'
import json,sys
json.load(open('nendoroid.ipynb'))
print("ok")
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684b6edc5920832e8f5b4ee1c1b76dfd