### PR TITLE
Add pytest scan for invalid en-dash sequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/tests/test_no_endash.py
+++ b/tests/test_no_endash.py
@@ -1,0 +1,25 @@
+import pathlib
+
+
+def find_files_with_endashO():
+    root = pathlib.Path(__file__).resolve().parents[1]
+    problematic = []
+    for path in root.rglob('*'):
+        if path.is_file() and '.git' not in path.parts:
+            try:
+                text = path.read_text(encoding='utf-8')
+            except Exception:
+                try:
+                    text = path.read_text(encoding='latin-1')
+                except Exception:
+                    continue
+            if '–' + 'O' in text:
+                problematic.append(str(path.relative_to(root)))
+    return problematic
+
+
+def test_no_endash_O():
+    problematic = find_files_with_endashO()
+    en_dash = '–'
+    sequence = en_dash + 'O'
+    assert not problematic, f"Found forbidden sequence {sequence!r} in files: {problematic}"


### PR DESCRIPTION
## Summary
- add pytest configuration
- add test to ensure no `–O` character combination exists in repo

## Testing
- `pytest -q` *(fails: Found forbidden sequence '–O' in notebooks)*

------
https://chatgpt.com/codex/tasks/task_e_684b6edf6f5c832e80cfc1d42a3b72ca